### PR TITLE
Add a SELINUX relabel function for RHEL-like oses

### DIFF
--- a/common.sh.in
+++ b/common.sh.in
@@ -410,6 +410,25 @@ setup_console() {
     esac
 }
 
+filesystem_check() {
+    local target=$1
+    if [ -z "$target" ] ; then
+        log_error "target not set for filesystem_check"
+        exit 1
+    fi
+
+    get_os $target
+
+    case "${OPERATING_SYSTEM}" in
+       fedora|centos|redhat)
+        # we have to force a filesystem relabeling for SELinux after messing
+        # around with the filesystem in fedora
+        echo "Enforce an automatic relabeling in the initial boot process..."
+        touch $target/.autorelabel
+       ;;
+    esac
+}
+
 cleanup() {
   if [ ${#CLEANUP[*]} -gt 0 ]; then
     LAST_ELEMENT=$((${#CLEANUP[*]}-1))

--- a/create
+++ b/create
@@ -119,6 +119,8 @@ if [ "$CDINSTALL" = "no" ] ; then
         setup_console $TARGET
     fi
 
+    filesystem_check $TARGET
+
     RUN_PARTS=`which run-parts`
 
     if [ -n "$RUN_PARTS" -a -n "$CUSTOMIZE_DIR" -a -d "$CUSTOMIZE_DIR" ]; then


### PR DESCRIPTION
This was commited by `Nikos Skalkotos <skalkoto@gmail.com>` on 05-2011 with the following comment:

Forced filesystem relabeling in the initial boot of a Fedora image. This is needed by SELinux in recent Fedora releases, because in any other case, SELinux will consider files that were externally altered by gnt-instance-image scripts as being in a inconsistent state and will not permit the system to use them, causing a denial of service.
