### PR TITLE
Various fixes

### DIFF
--- a/common.sh.in
+++ b/common.sh.in
@@ -422,12 +422,12 @@ filesystem_check() {
     get_os $target
 
     case "${OPERATING_SYSTEM}" in
-       fedora|centos|redhat)
-        # we have to force a filesystem relabeling for SELinux after messing
-        # around with the filesystem in fedora
-        echo "Enforce an automatic relabeling in the initial boot process..."
-        touch $target/.autorelabel
-       ;;
+        fedora|centos|redhat)
+            # we have to force a filesystem relabeling for SELinux after messing
+            # around with the filesystem in fedora
+            echo "Enforce an automatic relabeling in the initial boot process..."
+            touch $target/.autorelabel
+            ;;
     esac
 }
 

--- a/common.sh.in
+++ b/common.sh.in
@@ -109,7 +109,7 @@ get_api20_parameters() {
     exit 1
   fi
   IMG_ID=$OSP_IMG_ID
-  IMG_FORMAT=$OSP_IMG_FORMAT
+  IMAGE_TYPE=$OSP_IMG_FORMAT
   IMG_SSH_KEY_URL=$OSP_IMG_SSH_KEY_URL
 }
 

--- a/example/hooks/cron_randomize
+++ b/example/hooks/cron_randomize
@@ -10,8 +10,6 @@ set -e
 
 debug set -x
 
-trap cleanup EXIT
-
 n=$RANDOM
 min=$(( n %= 30 ))
 
@@ -24,5 +22,6 @@ echo "$((min + 7)) 6 * * *  root    test -x /usr/sbin/anacron || ( cd / && run-p
 echo "$((min + 13)) 6 * * 7 root    test -x /usr/sbin/anacron || ( cd / && run-parts --report cron.weekly )" >> ${TARGET}/etc/crontab
 echo "$((min + 24)) 6 1 * * root    test -x /usr/sbin/anacron || ( cd / && run-parts --report cron.monthly )" >> ${TARGET}/etc/crontab
 
+cleanup
 trap - EXIT
 exit 0

--- a/example/hooks/grub
+++ b/example/hooks/grub
@@ -28,10 +28,6 @@ set -e
 
 debug set -x
 
-CLEANUP=( )
-
-trap cleanup EXIT
-
 if [ -z "${TARGET}" -o ! -d "${TARGET}" ] ; then
     log_error "Missing target directory"
     exit 1

--- a/example/hooks/interfaces
+++ b/example/hooks/interfaces
@@ -212,5 +212,6 @@ else
     log_error "Unsupported OS_TYPE"
 fi
 
-
+cleanup
+trap - EXIT
 exit 0

--- a/example/hooks/root_ssh_key
+++ b/example/hooks/root_ssh_key
@@ -11,7 +11,7 @@ set -e
 debug set -x
 
 if [ -n "${IMG_SSH_KEY_URL}" ]; then
-       mkdir -p ${TARGET}/root/.ssh
+       ${MKDIR_P} ${TARGET}/root/.ssh
        wget -q -O "${TARGET}/root/.ssh/authorized_keys" "${IMG_SSH_KEY_URL}"
        echo "Succesfully injected ssh key"
 fi

--- a/example/hooks/root_ssh_key
+++ b/example/hooks/root_ssh_key
@@ -10,14 +10,13 @@ set -e
 
 debug set -x
 
-trap cleanup EXIT
-
 if [ -n "${IMG_SSH_KEY_URL}" ]; then
        mkdir -p ${TARGET}/root/.ssh
        wget -q -O "${TARGET}/root/.ssh/authorized_keys" "${IMG_SSH_KEY_URL}"
        echo "Succesfully injected ssh key"
 fi
 
+cleanup
 trap - EXIT
 exit 0
 

--- a/tools/mount-disks.in
+++ b/tools/mount-disks.in
@@ -25,7 +25,7 @@ root_dev=$(map_partition $filesystem_dev root)
 boot_dev=$(map_partition $filesystem_dev boot)
 
 target="/tmp/${INSTANCE_NAME}_root"
-mkdir -p $target
+${MKDIR_P} $target
 
 # mount filesystems
 mount_disk0 $target

--- a/verify
+++ b/verify
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [ "$OSP_IMG_FORMAT" !=  "tarball" ] && [ "OSP_IMG_FORMAT" !=  "qemu" ] && [ "OSP_IMG_FORMAT" != "dump" ]; then
+if [ "$OSP_IMG_FORMAT" !=  "tarball" ] && [ "$OSP_IMG_FORMAT" !=  "qemu" ] && [ "$OSP_IMG_FORMAT" != "dump" ]; then
     echo "Wrong image format. Supported formats are: qemu, tarball, dump." 1>&2
     exit 1
 fi


### PR DESCRIPTION
NB: This commit has only the changes specific to the grnet repo (I PRed a batch of my other changes to upstream - osuosl repo). I realise I could just commit to this repo, but I am doing this as a PR too, so it is easier for @alexkiousis to review alongside the other PRs, and incorporate/cherry-pick/etc (as it touches parts of the code he is still PRing upstream too):

* change IMG_FORMAT= to IMAGE_TYPE= (g.i.i uses the latter)
* actually call cleanup at the end of two hooks
* remove extra CLEANUP=() in one hook (which resets cleanup tasks)
* remove unneeded setting of cleanup traps at start of hooks (already set
  in common.sh)
* add missing $ in two variable tests
* use $MKDIR_P instead of hardcoded mkdir -p in two files